### PR TITLE
Add colourlist feature

### DIFF
--- a/src-darkmark/DMContent.cpp
+++ b/src-darkmark/DMContent.cpp
@@ -344,6 +344,9 @@ void dm::DMContent::start_darknet()
 	names.push_back("* empty image *");
 
 	annotation_colours = DarkHelp::get_default_annotation_colours();
+	const std::string colorlist_filename = cfg().get_str(cfg_prefix + "markup_colours");
+	DarkHelp::load_custom_annotation_colours(colorlist_filename);
+	annotation_colours = DarkHelp::get_default_annotation_colours();
 	if (annotation_colours.empty() == false)
 	{
 		const auto & opencv_colour = annotation_colours.at(most_recent_class_idx % annotation_colours.size());
@@ -1231,7 +1234,7 @@ dm::DMContent & dm::DMContent::load_image(const size_t new_idx, const bool full_
 				}
 			}
 
-			// Sort the marks based on a gross (rounded) X and Y position of the midpoint.  This way when
+			// Sort the marks based on a gross (rounded) X and Y position of the midpoint.	This way when
 			// the user presses TAB or SHIFT+TAB the marks appear in a consistent and predictable order.
 			task = "sorting marks";
 			std::sort(marks.begin(), marks.end(),

--- a/src-launcher/StartupCanvas.cpp
+++ b/src-launcher/StartupCanvas.cpp
@@ -113,6 +113,7 @@ dm::StartupCanvas::StartupCanvas(const std::string & key, const std::string & di
 	darknet_configuration_filename	.addListener(this);
 	darknet_weights_filename		.addListener(this);
 	darknet_names_filename			.addListener(this);
+	colourlist_filename				.addListener(this);
 
 	Array<PropertyComponent *> properties;
 
@@ -145,6 +146,7 @@ dm::StartupCanvas::StartupCanvas(const std::string & key, const std::string & di
 	properties.add(new TextPropertyComponent(darknet_configuration_filename	, "darknet configuration"	, 1000, false, true));
 	properties.add(new TextPropertyComponent(darknet_weights_filename		, "darknet weights"			, 1000, false, true));
 	properties.add(new TextPropertyComponent(darknet_names_filename			, "classes/names"			, 1000, false, true));
+	properties.add(new TextPropertyComponent(colourlist_filename			, "markup colours"			, 1000, false, true));
 
 	pp.addProperties(properties);
 	properties.clear();
@@ -170,7 +172,7 @@ dm::StartupCanvas::~StartupCanvas()
 void dm::StartupCanvas::resized()
 {
 	const int margin_size		= 5;
-	const int number_of_lines	= 17;
+	const int number_of_lines	= 18;
 	const int height_per_line	= 25;
 	const int total_pp_height	= number_of_lines * height_per_line;
 
@@ -505,6 +507,7 @@ void dm::StartupCanvas::refresh()
 	darknet_configuration_filename	= cfg().getValue("project_" + cfg_key + "_cfg"					);
 	darknet_weights_filename		= cfg().getValue("project_" + cfg_key + "_weights"				);
 	darknet_names_filename			= cfg().getValue("project_" + cfg_key + "_names"				);
+	colourlist_filename				= cfg().getValue("project_" + cfg_key + "_markup_colours"		);
 
 	done = false;
 	t = std::thread(&StartupCanvas::initialize_on_thread, this);
@@ -842,3 +845,4 @@ void dm::StartupCanvas::calculate_size_of_directory()
 
 	return;
 }
+

--- a/src-launcher/StartupCanvas.hpp
+++ b/src-launcher/StartupCanvas.hpp
@@ -80,6 +80,7 @@ namespace dm
 		Value darknet_configuration_filename;
 		Value darknet_weights_filename;
 		Value darknet_names_filename;
+		Value colourlist_filename;
 
 		TableListBox table;
 

--- a/src-launcher/StartupWnd.cpp
+++ b/src-launcher/StartupWnd.cpp
@@ -613,6 +613,8 @@ void dm::StartupWnd::buttonClicked(Button * button)
 				cfg().setValue(prefix + "names"					, notebook_canvas->darknet_names_filename			);
 				cfg().setValue(prefix + "darknet_cfg_template"	, notebook_canvas->darknet_configuration_template	);
 				cfg().setValue(prefix + "timestamp"				, static_cast<int>(std::time(nullptr))				);
+				cfg().setValue(prefix + "markup_colours"			, notebook_canvas->colourlist_filename				);
+				
 
 				// Prior to 2020-05-30, there were many settings in configuration that were "global".  Every time a project
 				// was loaded, the settings were copied over to the global name.  This mess is because when it was first
@@ -623,7 +625,7 @@ void dm::StartupWnd::buttonClicked(Button * button)
 				// the settings they previously used with this project.
 				if (File(cfg_filename).existsAsFile())
 				{
-					// regex to find keyword/value pairs such as:   width=416
+					// regex to find keyword/value pairs such as:	width=416
 					const std::regex rgx("^(\\w+)[ \t]*=[ \t]*([0-9.]+)$");
 
 					std::ifstream ifs(cfg_filename.toStdString());


### PR DESCRIPTION
This is about UI convenience in DarkMark.
If the user needs to associate distinct colors to the classes she works on, a list of color values can be read from a  plain text file. Expected format is one color per line, given in RGB hex pairs. Lines starting with a # will be ignored.
Darkmark's launcher feaures a 'markup colours' field to accept the full file name. 

See darkmark_color_file.txt for an example.


[darkmark_color_file.txt](https://github.com/stephanecharette/DarkHelp/files/12841731/darkmark_color_file.txt)