### PR TITLE
Add dot‐mode toggle for annotations (20×20 filled circles)

### DIFF
--- a/src-darkmark/DMContent.cpp
+++ b/src-darkmark/DMContent.cpp
@@ -975,6 +975,15 @@ bool dm::DMContent::keyPressed(const KeyPress & key)
 		}
 		return true;
 	}
+	else if (keychar == 'v')
+    {
+        use_large_dots = ! use_large_dots;
+        
+        show_message(std::string("dot-mode: ") + (use_large_dots ? "on" : "off"));
+        rebuild_image_and_repaint();
+        return true;
+    }
+
 	else if (keychar == 'w')
 	{
 		toggle_black_and_white_mode();

--- a/src-darkmark/DMContent.hpp
+++ b/src-darkmark/DMContent.hpp
@@ -315,5 +315,7 @@ namespace dm
 			int askUserForNumberOfFrames();
 			void handleMassDeleteArea(const cv::Rect &areaInScreenCoords);
 			size_t massDeleteMarks(const cv::Rect2d &selectionArea, int classIdx);
+
+			bool use_large_dots = false;
 	};
 }


### PR DESCRIPTION
Dot mode lets you change the box marks to be viewed as dots (small little circles).
Great for really cluttered annotation sessions. Just press `v` to toggle

<img width="1334" height="1021" alt="image" src="https://github.com/user-attachments/assets/c44a81d7-fe53-4eb9-be14-fe2f2664facf" />

<img width="1330" height="1021" alt="image" src="https://github.com/user-attachments/assets/18b5b315-4bbc-4a7b-8f1c-760cb7f01dc5" />
