### PR TITLE
Add copy mark forward feature

### DIFF
--- a/src-darkmark/DMContent.hpp
+++ b/src-darkmark/DMContent.hpp
@@ -315,5 +315,6 @@ namespace dm
 			int askUserForNumberOfFrames();
 			void handleMassDeleteArea(const cv::Rect &areaInScreenCoords);
 			size_t massDeleteMarks(const cv::Rect2d &selectionArea, int classIdx);
+			void copySelectedMarkForward();
 	};
 }

--- a/src-dox/05_keyboard.dox
+++ b/src-dox/05_keyboard.dox
@@ -48,6 +48,7 @@ Key							| Saves Modified Marks First	| Description
 @p s (lowercase)			|								| Save the current image, with the markings (if any) to a new filename.  Think of this as "screenshot".  Screenshots must be saved in either @p .jpg or @p .png file format (default is @p PNG).
 @p S (uppercase)			|								| Same as @p 's' (lowercase) but the file will be saved at 100% zoom, not at the current zoom level.
 @p t						| yes							| Toggle image tiling.  See @ref ImageSize.
+@p u                        |                               | Copy a selected mark forward a specified number of frames.
 @p w						|								| Toggle black-and-white mode. Images remain unchanged on disk, but shown in black-and-white (not greyscale!) in the main DarkMark window.  This can be useful when annotating images of text documents.
 @p y (lowercase)			|								| Copy marks from previous (alphabetical) marked up image.
 @p Y (uppercase)			|								| Copy marks from next (alphabetical) marked up image.


### PR DESCRIPTION
Use `u` to copy a selected mark forward a specified number of frames.


![ukey](https://github.com/user-attachments/assets/665c67fd-5c55-4877-bc10-5cf0024d51ee)
